### PR TITLE
[FIX] name link of contributor

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -6,7 +6,7 @@
 - [ankurg132](https://github.com/ankurg132)
 - [anshshori2002](https://github.com/anshshori2002)
 - [shriharit04](https://github.com/shriharit04)
-- [maharshi-sinha] (https://github.com/maharshi-sinha)
+- [maharshi-sinha](https://github.com/maharshi-sinha)
 - [sameersahu007](https://github.com/SameerSahu007)
 - [iharshka](https://github.com/iharshka)
 - [Chinmay-03](https://github.com/Chinmay-03)


### PR DESCRIPTION
I fixed the syntax error linking of name of the contributor.